### PR TITLE
Replace python utilities in provisioning with software common

### DIFF
--- a/app/templates/bin/provision
+++ b/app/templates/bin/provision
@@ -9,7 +9,8 @@ fi
 
 # Ansible dependencies
 apt-get -qq -y update
-apt-get -qq -y install python-software-properties
+apt-get -qq -y install software-properties-common
+apt-get -qq -y install python-pycurl
 add-apt-repository -y ppa:rquillo/ansible &> /dev/null || exit 1
 apt-get -qq -y update
 


### PR DESCRIPTION
I found this implementation to work better with my system. The python-software-properties could not be located via command line; however, software-properties-common was and is an equivalent replacement that also allows PPA additions.

Also added python-pycurl as a dependency (provisioning failed on that part too).

Tested on Ubuntu 13.04 64-bit on a VM in Digital Ocean.
