### PR TITLE
Added default deploy-to option in old.rb config

### DIFF
--- a/app/templates/deployment/stages/old.rb
+++ b/app/templates/deployment/stages/old.rb
@@ -9,4 +9,5 @@ set :user,          "myuser"
 set :password,      "mypassword"
 set :ssh_options,   {}
 
+set :deploy_to,     "/path/to/mysite/genesis"
 set :remote_web,    "/path/to/mysite/public_html"


### PR DESCRIPTION
Without this option the execution script assumes the zip backup should be placed in vars/www/ which may not have the permissions needed to execute the mkdir command.
