### PR TITLE
Fix for salts replace

### DIFF
--- a/app/templates/web/wp-config.php
+++ b/app/templates/web/wp-config.php
@@ -16,7 +16,7 @@ require_once(dirname(__FILE__) . '/../bower_components/genesis-wordpress/src/Gen
   .replace(/define\('WP_DEBUG'.+\);/, "define('WP_DEBUG', WP_ENV === 'local');")
 
   // Replace salts
-  .replace(/define\('AUTH_KEY'[\s\S]+'put your unique phrase here'\);/, props.salts)
+  .replace(/(\/\*\*#@\+.+?\*\/\n).+?(\n\/\*\*#@-\*\/)/m, "$1" + props.salts + "$2")
 
   // Limit to 5 post revisions
   .replace("/* That's all,", "define('WP_POST_REVISIONS', 5);\n\n/*That's all,")


### PR DESCRIPTION
The regex replace for keys + salts in wp-config was failing in some instances (notably when working with certain existing wp-configs).

![screen shot 2013-10-22 at 10 45 51 am](https://f.cloud.github.com/assets/84145/1382728/3f44913e-3b32-11e3-8a7a-14e28b9f6a76.png)

This _should_ match everything from `/**#@+...*/` and `/**#@-*/`, and replace everything between them. (We should test the heck out of this before merging).
